### PR TITLE
Add parentOf and hasParent object properties for Organizations

### DIFF
--- a/metabolomics.owl
+++ b/metabolomics.owl
@@ -93,6 +93,16 @@
     
 
 
+    <!-- http://www.metabolomics.info/ontologies/2019/metabolomics-consortium#hasParent -->
+
+    <owl:ObjectProperty rdf:about="http://www.metabolomics.info/ontologies/2019/metabolomics-consortium#hasParent">
+        <owl:inverseOf rdf:resource="http://www.metabolomics.info/ontologies/2019/metabolomics-consortium#parentOf"/>
+        <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Organization"/>
+        <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Organization"/>
+    </owl:ObjectProperty>
+
+
+
     <!-- http://www.metabolomics.info/ontologies/2019/metabolomics-consortium#inCollection -->
 
     <owl:ObjectProperty rdf:about="http://www.metabolomics.info/ontologies/2019/metabolomics-consortium#inCollection">
@@ -137,6 +147,15 @@
         <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Organization"/>
     </owl:ObjectProperty>
     
+
+
+    <!-- http://www.metabolomics.info/ontologies/2019/metabolomics-consortium#parentOf -->
+
+    <owl:ObjectProperty rdf:about="http://www.metabolomics.info/ontologies/2019/metabolomics-consortium#parentOf">
+        <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Organization"/>
+        <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Organization"/>
+    </owl:ObjectProperty>
+
 
 
     <!-- http://www.metabolomics.info/ontologies/2019/metabolomics-consortium#produced -->


### PR DESCRIPTION
These are needed to express the parent-child relationship between two organizations. For example, an Institute (1234) has a Department (4242) can be expressed as:
```
<https://vivo.metabolomics.info/individual/1234> m3c:parentOf  <https://vivo.metabolomics.info/individual/4242> .
<https://vivo.metabolomics.info/individual/4242> m3c:hasParent <https://vivo.metabolomics.info/individual/1234> .
```